### PR TITLE
Allow Public Key exchanges on MySQL connections

### DIFF
--- a/src/main/java/pw/twpi/whitelistsync2/services/MySqlService.java
+++ b/src/main/java/pw/twpi/whitelistsync2/services/MySqlService.java
@@ -33,7 +33,7 @@ public class MySqlService implements BaseService {
 
     public MySqlService() {
         this.databaseName = Config.MYSQL_DB_NAME.get();
-        this.url = "jdbc:mysql://" + Config.MYSQL_IP.get() + ":" + Config.MYSQL_PORT.get() + "/?useSSL=false&serverTimezone=UTC";
+        this.url = "jdbc:mysql://" + Config.MYSQL_IP.get() + ":" + Config.MYSQL_PORT.get() + "/?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=UTC";
         this.username = Config.MYSQL_USERNAME.get();
         this.password = Config.MYSQL_PASSWORD.get();
     }


### PR DESCRIPTION
This change should fix issue #19 

Another solution would be to remove "allowpublickeyretrieval" AND useSSL if you don't want to enable public key exchange.